### PR TITLE
关于Cron示例的修改

### DIFF
--- a/docs/service.rst
+++ b/docs/service.rst
@@ -307,7 +307,7 @@ config.yaml::
 
     cron:
     - url: /backend/cron/update
-      schedule: */5 * * * *
+      schedule: every 5 mins
 
     handle:
     - hostaccess: if(path ~ "/backend/") allow "10.0.0.0/8"


### PR DESCRIPTION
本次修改的Cron示例在未修改前，即使直接复制也无法通过saecloud上传config.yaml文件。原因是.yaml文件中出现了'/'符号，这是非法的，因为.yaml文件中只允许出现数字和字母。

建议修改。
