### PR TITLE
修正中文邮件问题

### DIFF
--- a/dev_server/sae/mail.py
+++ b/dev_server/sae/mail.py
@@ -223,6 +223,7 @@ class EmailMessage(object):
 
         import smtplib
         from email import encoders
+        from email.Header import Header
         from email.mime.text import MIMEText
         from email.MIMEBase import MIMEBase
         from email.MIMEMultipart import MIMEMultipart
@@ -238,12 +239,12 @@ class EmailMessage(object):
         msg = MIMEMultipart()
         msg['From'] = args['from']
         msg['To'] = args['to']
-        msg['Subject'] = args['subject']
+        msg['Subject'] = Header(args['subject'],'utf-8').encode()
 
         if args['content_type'] == 'plain':
-            msg.attach(MIMEText(args['content']))
+            msg.attach(MIMEText(args['content'], _charset="utf-8"))
         else:
-            msg.attach(MIMEText(args['content'], 'html'))
+            msg.attach(MIMEText(args['content'], 'html', _charset="utf-8"))
 
         for k, v in args.iteritems():
             if not k.startswith('attach'):


### PR DESCRIPTION
修正了原先mail部分无法包括中文的问题，包括将标题和内容进行编码。编码格式为utf-8
