### PR TITLE
fix win7 path issue due to path join problem.

### DIFF
--- a/dev_server/saecloud
+++ b/dev_server/saecloud
@@ -20,7 +20,7 @@ from sae.util import search_file_bottom_up
 UPLOAD_SERVER = 'http://upload.sae.sina.com.cn'
 DEPLOY_SERVER = 'http://deploy.sae.sina.com.cn'
 SVN_SERVER = 'https://svn.sinaapp.com/'
-LOCAL_CACHE_DIR = os.path.expanduser('~/.saecloud')
+LOCAL_CACHE_DIR = os.path.join(os.path.expanduser('~'),'.saecloud')
 
 VERSION = '0.0.1'
 verbose = False


### PR DESCRIPTION
if this patch would not be adopted, then in windows saecloud shell commands would appear errors like
"Can not find path "C:\Users\xxx/.saecloud\shell.hist" or something like that, due to the fault caused by '~/.saecloud'.

Tested in Windows7, python 2.7.3 and latest repo of sae.
